### PR TITLE
KB21-19 fixes maven repository and adds a bash script

### DIFF
--- a/fix_pom_https.sh
+++ b/fix_pom_https.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Define the target file
+POM_FILE="pom.xml"
+
+# Check if the file exists
+if [[ ! -f "$POM_FILE" ]]; then
+    echo "Error: $POM_FILE not found!"
+    exit 1
+fi
+
+# Replace all http:// with https:// in the pom.xml file
+sed -i 's|http://|https://|g' "$POM_FILE"
+
+echo "Updated $POM_FILE: All HTTP URLs changed to HTTPS."

--- a/pom.xml
+++ b/pom.xml
@@ -584,11 +584,11 @@
         <repository>
             <id>org.springframework.maven.milestone</id>
             <name>Spring Maven Milestone Repository</name>
-            <url>http://repo.spring.io/milestone</url>
+            <url>https://repo.spring.io/milestone</url>
         </repository>
         <repository>
             <id>public</id>
-            <url>http://maven.nuxeo.org/nexus/content/groups/public</url>
+            <url>https://maven.nuxeo.org/nexus/content/groups/public</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -599,7 +599,7 @@
 
         <repository>
             <id>public-snapshot</id>
-            <url>http://maven.nuxeo.org/nexus/content/groups/public-snapshot</url>
+            <url>https://maven.nuxeo.org/nexus/content/groups/public-snapshot</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -613,19 +613,19 @@
         <repository>
             <id>spring-milestone</id>
             <name>Spring Maven MILESTONE Repository</name>
-            <url>http://repo.spring.io/libs-milestone</url>
+            <url>https://repo.spring.io/libs-milestone</url>
         </repository>
 </repositories>
 <distributionManagement>
     <repository>
       <id>nexus</id>
       <name>Releases</name>
-      <url>http://35.188.29.52:8081/repository/maven-releases</url>
+      <url>https://35.188.29.52:8081/repository/maven-releases</url>
     </repository>
     <snapshotRepository>
       <id>nexus</id>
       <name>Snapshot</name>
-      <url>http://35.188.29.52:8081/repository/maven-snapshots</url>
+      <url>https://35.188.29.52:8081/repository/maven-snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 </project>


### PR DESCRIPTION
## Describe your changes  
- Manually fixed the repository URLs in `pom.xml`, changing `http://` to `https://` to resolve Maven dependency issues.  
- Created a Bash script (`fix_pom_https.sh`) to automate this process for future updates.  

## Issue ticket number and link  
<!-- Add the issue number and link if applicable -->  

## Checklist before requesting a review  
- [x] I have performed a self-review of my code  
- [ ] If it is a core feature, I have added thorough tests.  
- [ ] Do we need to implement analytics?  
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.  
